### PR TITLE
fix: Update lib package.json

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,15 @@
+# Cypress Playback
+
+> 🔄 **_Automatically record and playback HTTP requests made in
+> Cypress tests._**
+
+Cypress Playback is a plugin and a set of commands that allows Cypress to
+automatically record responses to network requests made during a test run. These
+responses are then saved to disk and made available for playback in later test
+runs. This allows for applications or components under test to always receive
+the same response to a request, no matter where or when they run.
+
+For details on how to integrate this plugin into Cypress and how it works,
+please refer to the [README][1] in GitHub.
+
+[1]:https://github.com/oreillymedia/cypress-playback#cypress-playback

--- a/lib/package.json
+++ b/lib/package.json
@@ -9,9 +9,23 @@
     "test": "c8 --all mocha",
     "test:watch": "mocha --watch"
   },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oreillymedia/cypress-playback.git"
+  },
+  "bugs": {
+    "url": "https://github.com/oreillymedia/cypress-playback/issues"
+  },
+  "homepage": "https://github.com/oreillymedia/cypress-playback#readme",
+  "keywords": [
+    "cypress",
+    "cypress-plugin",
+    "fixtures",
+    "requests",
+    "snapshots"
+  ],
+  "author": "O'Reilly Media",
+  "license": "BSD-3-Clause",
   "dependencies": {
     "blueimp-md5": "^2.19.0",
     "lodash.kebabcase": "^4.1.1"


### PR DESCRIPTION
### Summary

- Update the `lib` folder's package.json with fields that were found in the root folder version.
- Add small README to `lib` folder that will show up in NPM and redirects users to GitHub README.

### Related Issue(s)

n/a

### Checklist

* [X] Follows [Contributing guidelines][1].
* [X] Pull Request title uses [Conventional Commit syntax][2].
* [X] All tests pass.
* [X] Linted code.
* [X] Authored new tests, if necessary.
* [X] Updated documentation, if necessary.

[1]:https://github.com/oreillymedia/cypress-playback/blob/main/CONTRIBUTING.md
[2]:https://www.conventionalcommits.org/en/v1.0.0/#summary