### PR TITLE
fix: Handle multiple set-cookie headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 coverage/
 node_modules/
+sandbox/cypress/fixtures/private/
+sandbox/cypress/integration/private/
 sandbox/cypress/screenshots/
 sandbox/cypress/videos/
 secrets/

--- a/lib/commands/entities/PlaybackRequestMatcher.js
+++ b/lib/commands/entities/PlaybackRequestMatcher.js
@@ -10,6 +10,10 @@ class PlaybackRequestMatcher {
   /**
    * @type {string}
    */
+  #method = null;
+  /**
+   * @type {string}
+   */
   #matcher = null;
   /**
    * @type {number}
@@ -41,6 +45,7 @@ class PlaybackRequestMatcher {
   stale = false;
 
   get id() { return this.#id; }
+  get method() { return this.#method; }
   get matcher() { return this.#matcher; }
   get minTimes() { return this.#minTimes; }
   /**
@@ -64,6 +69,7 @@ class PlaybackRequestMatcher {
           throw new Error('Invalid arguments');
         }
         this.#id = getRequestMatcherId(method, matcher, options);
+        this.#method = method;
         this.#matcher = getMatcherAsString(matcher);
         this.#minTimes = options.minTimes ?? 1;
         /* c8 ignore next*/
@@ -136,6 +142,7 @@ class PlaybackRequestMatcher {
   serialize() {
     return {
       id: this.#id,
+      method: this.#method,
       matcher: this.#matcher,
       minTimes: this.#minTimes,
       ignoredAttributes: this.#ignoredAttributes,
@@ -147,6 +154,7 @@ class PlaybackRequestMatcher {
 
   deserialize(data) {
     this.#id = data.id;
+    this.#method = data.method;
     this.#matcher = data.matcher;
     this.#minTimes = data.minTimes;
     this.#ignoredAttributes = data.ignoredAttributes;

--- a/lib/commands/entities/PlaybackResponse.js
+++ b/lib/commands/entities/PlaybackResponse.js
@@ -20,6 +20,9 @@ function getResponseBodyType(body) {
 }
 
 function serializeResponseBody(body, bodyType) {
+  if (bodyType === null) {
+    return undefined;
+  }
   if (bodyType === 'ArrayBuffer') {
     return arrayBufferToBase64(new Uint8Array(body));
   } else if (bodyType === 'json') {
@@ -28,10 +31,13 @@ function serializeResponseBody(body, bodyType) {
     return body;
   }
   /* c8 ignore next*/
-  throw new Error(`Unknown body type: ${bodyType}`);
+  throw new Error(`Cannot serialize unknown body type: ${bodyType}`);
 }
 
 function deserializeResponseBody(body, bodyType) {
+  if (bodyType === null) {
+    return undefined;
+  }
   if (bodyType === 'ArrayBuffer') {
     return base64ToArrayBuffer(body);
   } else if (bodyType === 'json') {
@@ -40,7 +46,7 @@ function deserializeResponseBody(body, bodyType) {
     return body;
   }
   /* c8 ignore next*/
-  throw new Error(`Unknown body type: ${bodyType}`);
+  throw new Error(`Cannot deserialize unknown body type: ${bodyType}`);
 }
 
 class PlaybackResponse {

--- a/lib/commands/entities/tests/PlaybackRequestMap.spec.js
+++ b/lib/commands/entities/tests/PlaybackRequestMap.spec.js
@@ -185,6 +185,7 @@ describe('PlaybackRequestMap', () => {
         matchers: [{
           id: 'mock-request-matcher-id',
           ignoredAttributes: [],
+          method: 'GET',
           matcher: '/example',
           minTimes: 2,
           responses: [

--- a/lib/commands/entities/tests/PlaybackRequestMatcher.spec.js
+++ b/lib/commands/entities/tests/PlaybackRequestMatcher.spec.js
@@ -16,6 +16,8 @@ function createSerializedRequestMatcher(id, minTimes, responseCount, ignoredAttr
   for (let i = 0; i < responseCount; i++) {
     responses.push({
       id: `mock-intercepted-response-id-${i + 1}`,
+      method: 'GET',
+      matcher: '/foo/bar',
       statusCode: 200,
       statusMessage: 'OK',
       body: 'body-string',
@@ -74,12 +76,16 @@ describe('PlaybackRequestMatcher', () => {
 
   describe('deserialization', () => {
     it('works', () => {
+      // Arrange
+      const serialized = createSerializedRequestMatcher('mock-id', 2, 3);
       // Act
-      const matcher = new PlaybackRequestMatcher(createSerializedRequestMatcher('mock-id', 2, 3));
+      const matcher = new PlaybackRequestMatcher(serialized);
 
       // Assert
       expect(matcher.id).to.equal('mock-id');
       expect(matcher.minTimes).to.equal(2);
+      expect(matcher.method).to.equal(serialized.method);
+      expect(matcher.matcher).to.equal(serialized.matcher);
       expect(matcher.stale).to.be.true;
       for (let i = 1; i <= 3; i++) {
         expect(matcher.getResponse(`mock-intercepted-response-id-${i}`)).property('hits').to.equal(1);
@@ -108,6 +114,7 @@ describe('PlaybackRequestMatcher', () => {
       expect(serialized).to.deep.equal({
         id: 'mock-request-id',
         ignoredAttributes: [],
+        method: 'GET',
         matcher: 'http://example.com/',
         minTimes: 5,
         responses: [{

--- a/lib/commands/entities/tests/PlaybackResponse.spec.js
+++ b/lib/commands/entities/tests/PlaybackResponse.spec.js
@@ -78,6 +78,7 @@ describe('PlaybackResponse', () => {
       { body: '{"foo":"bar"}', bodyType: 'json', expected: { foo: 'bar' } },
       { body: 'body-string', bodyType: 'string', expected: 'body-string' },
       { body: 'Y2hlZXNl', bodyType: 'ArrayBuffer', expected: new Uint8Array(Buffer.from('Y2hlZXNl', 'base64')) },
+      { body: undefined, bodyType: null, expected: undefined},
     ];
 
     for (const { body, bodyType, expected } of cases) {
@@ -115,13 +116,14 @@ describe('PlaybackResponse', () => {
     });
 
     const cases = [
-      { body: { foo: 'bar' }, bodyType: 'json', expected: '{"foo":"bar"}' },
-      { body: 'body-string', bodyType: 'string', expected: 'body-string' },
-      { body: new Uint8Array(Buffer.from('Y2hlZXNl', 'base64')), bodyType: 'ArrayBuffer', expected: 'Y2hlZXNl' },
+      { body: { foo: 'bar' }, expectedBodyType: 'json', expected: '{"foo":"bar"}' },
+      { body: 'body-string', expectedBodyType: 'string', expected: 'body-string' },
+      { body: new Uint8Array(Buffer.from('Y2hlZXNl', 'base64')), expectedBodyType: 'ArrayBuffer', expected: 'Y2hlZXNl' },
+      { body: undefined, expectedBodyType: null, expected: undefined },
     ];
 
-    for (const { body, bodyType, expected } of cases) {
-      it(`should handle a bodyType of "${bodyType}"`, () => {
+    for (const { body, expectedBodyType, expected } of cases) {
+      it(`should handle a bodyType of "${expectedBodyType}"`, () => {
         const playbackResponse = new PlaybackResponse(...createConstructorArgs(body));
 
         // Act
@@ -132,7 +134,7 @@ describe('PlaybackResponse', () => {
         expect(serialized.statusCode).to.equal(200);
         expect(serialized.statusMessage).to.equal('OK');
         expect(serialized.body).to.equal(expected);
-        expect(serialized.bodyType).to.equal(bodyType);
+        expect(serialized.bodyType).to.equal(expectedBodyType);
         expect(serialized.headers).to.deep.equal({ 'mock-header': 'yes' });
       });
     }

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -55,6 +55,7 @@ afterEach(function playbackAfterEach() {
     message: 'Checking for pending requests...',
     consoleProps: () => ({
       'Pending Requests': [],
+      'All Requests': [],
     })
   });
 
@@ -78,11 +79,13 @@ afterEach(function playbackAfterEach() {
     })
     .then(() => {
       if (map.hasPendingRequests()) {
-        const pendingRequests = map.getPendingRequests().map(request => request.matcher);
+        const pendingRequests = map.getPendingRequests().map(request => `${request.method} ${request.matcher}`);
+        const allRequests = map.getAll().map(request => `${request.method} ${request.matcher}`);
         // Update the log for the error state.
         log.set('message', `${pendingRequests.length} pending requests.`)
           .set('consoleProps', () => ({
             'Pending Requests': pendingRequests,
+            'All Requests': allRequests,
           }))
           .error()
           .end();
@@ -116,7 +119,12 @@ const playback = {
       if (isPlaybackMode('playback')) {
         const response = map.getResponse(id, req, options);
         if (response) {
-          req.reply(response);
+          try {
+            req.reply(response.statusCode,response.body, response.headers);
+          } catch (e) {
+            console.error(response);
+            throw e;
+          }
           return;
         } else if (!isPlaybackMode('hybrid')) {
           // TODO: Improve error message.

--- a/sandbox/cypress/support/index.js
+++ b/sandbox/cypress/support/index.js
@@ -13,6 +13,8 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
+import '@testing-library/cypress/add-commands';
+
 // Import commands.js using ES2015 syntax:
 import './commands'
 

--- a/sandbox/package-lock.json
+++ b/sandbox/package-lock.json
@@ -9,9 +9,119 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@testing-library/cypress": "^8.0.2",
         "cypress": "^9.0.0",
         "http-server": "^14.1.0",
         "start-server-and-test": "^1.14.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -96,6 +206,48 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
+    "node_modules/@testing-library/cypress": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.2.tgz",
+      "integrity": "sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.14.6",
+        "@testing-library/dom": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.3.tgz",
+      "integrity": "sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -206,6 +358,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -690,6 +851,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.11.tgz",
+      "integrity": "sha512-7X6GvzjYf4yTdRKuCVScV+aA9Fvh5r8WzWrXBH9w82ZWB/eYDMGCnazoC/YAqAzUJWHzLOnZqr46K3iEyUhUvw==",
+      "dev": true
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -1269,6 +1436,12 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -1425,6 +1598,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/map-stream": {
@@ -1675,6 +1857,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.4.6",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
+      "integrity": "sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -1739,6 +1947,18 @@
       "engines": {
         "node": ">=0.4.x"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "node_modules/request-progress": {
       "version": "3.0.0",
@@ -2249,6 +2469,93 @@
     }
   },
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.16.7"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@cypress/request": {
       "version": "2.88.10",
       "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
@@ -2332,6 +2639,38 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
     },
+    "@testing-library/cypress": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.2.tgz",
+      "integrity": "sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.14.6",
+        "@testing-library/dom": "^8.1.0"
+      }
+    },
+    "@testing-library/dom": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.3.tgz",
+      "integrity": "sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.18.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz",
@@ -2404,6 +2743,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
       "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true
+    },
+    "aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
       "dev": true
     },
     "asn1": {
@@ -2770,6 +3115,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.11.tgz",
+      "integrity": "sha512-7X6GvzjYf4yTdRKuCVScV+aA9Fvh5r8WzWrXBH9w82ZWB/eYDMGCnazoC/YAqAzUJWHzLOnZqr46K3iEyUhUvw==",
       "dev": true
     },
     "duplexer": {
@@ -3203,6 +3554,12 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -3322,6 +3679,12 @@
           }
         }
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
     },
     "map-stream": {
       "version": "0.1.0",
@@ -3516,6 +3879,25 @@
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
       "dev": true
     },
+    "pretty-format": {
+      "version": "27.4.6",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
+      "integrity": "sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        }
+      }
+    },
     "proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -3563,6 +3945,18 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
       "dev": true
     },
     "request-progress": {

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@testing-library/cypress": "^8.0.2",
     "cypress": "^9.0.0",
     "http-server": "^14.1.0",
     "start-server-and-test": "^1.14.0"


### PR DESCRIPTION
### Summary

- Use the `req.reply(statusCode, body, headers)` method signature for replaying recorded responses.
	- This is necessary because the Cypress `req.reply(<StaticResponse>)` method throws an error if there are any headers whose values are arrays. This is the case with `set-cookie` headers.
	- That is triggered by [this validation][3].
- Fix handling responses with no body.
	- Those responses have the default `null` value for their `bodyType`, which previously wasn't handled by the serialize / deserialize functions.
- Improve pending request error log to show more details about the unresolved pending requests and provide a list of all the requests.
- Add "private" folders to `.gitignore` file to allow developers to work with tests specific to sites they work on without fear of checking those files into the repo.

### Related Issue(s)

n/a

### Checklist

* [x] Follows [Contributing guidelines][1].
* [x] Pull Request title uses [Conventional Commit syntax][2].
* [x] All tests pass.
* [ ] Linted code.
* [x] Authored new tests, if necessary.
* [x] Updated documentation, if necessary.

[1]:https://github.com/oreillymedia/cypress-playback/blob/main/CONTRIBUTING.md
[2]:https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]:https://github.com/cypress-io/cypress/blob/8e23567d5b2b851d9302c0019ae0e62ff546604d/packages/driver/src/cy/net-stubbing/static-response-utils.ts#L41-L43