### PR TITLE
feat: Add additional ignores, single response support

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -3,6 +3,9 @@
 > 🔄 **_Automatically record and playback HTTP requests made in
 > Cypress tests._**
 
+[![GitHub CI](https://img.shields.io/github/workflow/status/oreillymedia/cypress-playback/Continuous%20Integration/main)][1]
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)][3]
+
 Cypress Playback is a plugin and a set of commands that allows Cypress to
 automatically record responses to network requests made during a test run. These
 responses are then saved to disk and made available for playback in later test
@@ -10,6 +13,8 @@ runs. This allows for applications or components under test to always receive
 the same response to a request, no matter where or when they run.
 
 For details on how to integrate this plugin into Cypress and how it works,
-please refer to the [README][1] in GitHub.
+please refer to the [README][2] in GitHub.
 
-[1]:https://github.com/oreillymedia/cypress-playback#cypress-playback
+[1]:https://github.com/oreillymedia/cypress-playback
+[2]:https://github.com/oreillymedia/cypress-playback#cypress-playback
+[3]:https://github.com/oreillymedia/cypress-playback/blob/main/CODE-OF-CONDUCT.md

--- a/lib/commands/constants.js
+++ b/lib/commands/constants.js
@@ -3,7 +3,7 @@ const ENV_MODE = 'PLAYBACK_MODE';
 /**
  * The current version of the serialized requests and responses.
  */
-const SERIALIZE_VERSION = 1;
+const SERIALIZE_VERSION = 2;
 
 module.exports = {
   CONFIG_KEY,

--- a/lib/commands/entities/PlaybackRequestMap.js
+++ b/lib/commands/entities/PlaybackRequestMap.js
@@ -93,7 +93,7 @@ class PlaybackRequestMap {
     return matcher.getResponse(getInterceptedResponseId(
       interceptedRequest,
       /* c8 ignore next*/
-      options.recording?.matchingIgnores ?? []
+      options.matching?.ignores ?? []
     ));
   }
 

--- a/lib/commands/entities/PlaybackRequestMatcher.js
+++ b/lib/commands/entities/PlaybackRequestMatcher.js
@@ -12,21 +12,30 @@ class PlaybackRequestMatcher {
    */
   #method = null;
   /**
+   * A stringified version of the request matcher value.
    * @type {string}
    */
   #matcher = null;
   /**
+   * The minimum number of times the request must be called.
    * @type {number}
    */
-  #minTimes = 1;
+  #atLeast = 1;
   /**
-   * @type {InterceptedResponseAttributes[]}
+   * What elements of a network request are ignored for response matching.
+   * @type {InterceptedResponseAttributes[] | ResponseMatchingIgnores}
    */
-  #ignoredAttributes = [];
+  #ignores = [];
   /**
    * @type {Map<string, PlaybackResponse>}
    */
   #responses = new Map();
+  /**
+   * When true, any response matching is ignored if only a single response is
+   * recorded for this request matcher.
+   * @type {boolean}
+   */
+  #anyOnce = false;
 
   /**
    * The number of requests that were intercepted by this matcher but which have
@@ -47,12 +56,13 @@ class PlaybackRequestMatcher {
   get id() { return this.#id; }
   get method() { return this.#method; }
   get matcher() { return this.#matcher; }
-  get minTimes() { return this.#minTimes; }
+  get anyOnce() { return this.#anyOnce; }
+  get toBeCalledAtLeast() { return this.#atLeast; }
   /**
    * Which attributes of an intercepted response should be ignored when
    * generating an id for the response.
    */
-  get ignoredAttributes() { return this.#ignoredAttributes; }
+  get ignores() { return this.#ignores; }
 
   constructor(
     ...args
@@ -71,9 +81,21 @@ class PlaybackRequestMatcher {
         this.#id = getRequestMatcherId(method, matcher, options);
         this.#method = method;
         this.#matcher = getMatcherAsString(matcher);
-        this.#minTimes = options.minTimes ?? 1;
+        this.#atLeast = options.toBeCalledAtLeast ?? 1;
+        this.#anyOnce = options.matching?.anyOnce ?? false;
         /* c8 ignore next*/
-        this.#ignoredAttributes = options.recording?.matchingIgnores ?? [];
+        this.#ignores = options.matching?.ignores ?? [];
+
+        if (this.#anyOnce) {
+          if (this.#atLeast > 1) {
+            throw new RangeError('"toBeCalledAtLeast" must be 1 if "matching.anyOnce" is true');
+          }
+          // Object.keys works on both a simple object and an array.
+          if (Object.keys(this.#ignores).length) {
+            console.warn('"matching.ignores" is unnecessary when "matching.anyOnce" is true');
+          }
+        }
+
         break;
       }
       default: {
@@ -107,7 +129,7 @@ class PlaybackRequestMatcher {
       body,
       headers,
       interceptedRequest,
-      this.#ignoredAttributes
+      this.#ignores
     );
     if (this.#responses.has(response.id)) {
       response = this.#responses.get(response.id);
@@ -115,14 +137,25 @@ class PlaybackRequestMatcher {
       this.#responses.set(response.id, response);
     }
     response.addHit();
+    if (response.hits > 1 && this.#anyOnce) {
+      throw new Error('Request matcher has "matching.anyOnce" set on it, but has recorded more than one response.');
+    }
   }
 
   getResponse(responseId) {
-    const response = this.#responses.get(responseId);
+    let response = this.#responses.get(responseId);
+    if (!response && this.#anyOnce && this.#responses.size === 1) {
+      // Get the 1st and only response in the map.
+      response = this.#responses.values().next().value;
+    }
     if (response) {
       response.addHit();
     }
     return response;
+  }
+
+  getAllResponses() {
+    return Array.from(this.#responses.values());
   }
 
   isPending() {
@@ -136,7 +169,7 @@ class PlaybackRequestMatcher {
     for (const response of this.#responses.values()) {
       hits += response.hits;
     }
-    return hits < this.#minTimes;
+    return hits < this.#atLeast;
   }
 
   serialize() {
@@ -144,8 +177,9 @@ class PlaybackRequestMatcher {
       id: this.#id,
       method: this.#method,
       matcher: this.#matcher,
-      minTimes: this.#minTimes,
-      ignoredAttributes: this.#ignoredAttributes,
+      atLeast: this.#atLeast,
+      anyOnce: this.#anyOnce,
+      ignores: this.#ignores,
       responses: Array.from(this.#responses.values())
         .filter(response => response.hits > 0)
         .map(response => response.serialize())
@@ -156,8 +190,9 @@ class PlaybackRequestMatcher {
     this.#id = data.id;
     this.#method = data.method;
     this.#matcher = data.matcher;
-    this.#minTimes = data.minTimes;
-    this.#ignoredAttributes = data.ignoredAttributes;
+    this.#atLeast = data.atLeast;
+    this.#anyOnce = data.anyOnce;
+    this.#ignores = data.ignores;
     // Assume that a request being deserialized is stale.
     this.stale = true;
     data.responses.forEach(entry => {

--- a/lib/commands/entities/PlaybackResponse.js
+++ b/lib/commands/entities/PlaybackResponse.js
@@ -1,4 +1,4 @@
-const { getInterceptedResponseId: getInterceptedResponseId } = require('../functions/getInterceptedResponseId');
+const { getInterceptedResponseId } = require('../functions/getInterceptedResponseId');
 const { arrayBufferToBase64, base64ToArrayBuffer } = require('../functions/arrayBufferFns');
 
 const jsonStringableTypes = ['string', 'number', 'boolean'];
@@ -92,7 +92,7 @@ class PlaybackResponse {
    * @param {any} body
    * @param {{[key: string]: string}} headers
    * @param {CypressInterceptedRequest} interceptedRequest
-   * @param {InterceptedResponseAttributes[]} ignoredAttributes
+   * @param {ResponseMatchingIgnores} ignores
    */
   constructor(...args) {
     switch (args.length) {
@@ -101,7 +101,7 @@ class PlaybackResponse {
         break;
       }
       case 6: {
-        const [statusCode, statusMessage, body, headers, interceptedRequest, ignoredAttributes] = args;
+        const [statusCode, statusMessage, body, headers, interceptedRequest, ignores] = args;
         this.#statusCode = statusCode;
         this.#statusMessage = statusMessage;
         this.#body = body;
@@ -110,7 +110,7 @@ class PlaybackResponse {
           this.#bodyType = getResponseBodyType(body);
         }
         if (interceptedRequest) {
-          this.#id = getInterceptedResponseId(interceptedRequest, ignoredAttributes);
+          this.#id = getInterceptedResponseId(interceptedRequest, ignores);
         }
         break;
       }

--- a/lib/commands/entities/tests/PlaybackRequestMap.spec.js
+++ b/lib/commands/entities/tests/PlaybackRequestMap.spec.js
@@ -24,7 +24,7 @@ function createSerializedMap(matcherCount = 1, responseCount = 1) {
     }
     matchers.push({
       id: `mock-request-id-${i}`,
-      minTimes: responseCount,
+      atLeast: responseCount,
       responses
     });
   }
@@ -125,7 +125,7 @@ describe('PlaybackRequestMap', () => {
       const responseId = serializedMap.matchers[0].id;
 
       // This will cause the existing request id to be returned.
-      td.when(getRequestMatcherId('GET', '/example', { minTimes: 2 }))
+      td.when(getRequestMatcherId('GET', '/example', { toBeCalledAtLeast: 2 }))
         .thenReturn(responseId);
 
       const map = new PlaybackRequestMap('file-1', 'title-1', serializedMap);
@@ -134,7 +134,7 @@ describe('PlaybackRequestMap', () => {
       expect(map.hasPendingRequests()).to.be.false;
 
       // Act
-      map.add('GET', '/example', { minTimes: 2 });
+      map.add('GET', '/example', { toBeCalledAtLeast: 2 });
 
       // Assert
       expect(map.hasPendingRequests()).to.be.true;
@@ -152,7 +152,7 @@ describe('PlaybackRequestMap', () => {
   describe('adding responses and serialization', () => {
     it('works', () => {
       // Arrange
-      td.when(getRequestMatcherId('GET', '/example', { minTimes: 2 }))
+      td.when(getRequestMatcherId('GET', '/example', { toBeCalledAtLeast: 2 }))
         .thenReturn('mock-request-matcher-id');
 
       // Setup mocks to return ids from the mock responses.
@@ -167,12 +167,12 @@ describe('PlaybackRequestMap', () => {
       expect(map.hasPendingRequests()).to.be.false;
 
       // Act
-      const id = map.add('GET', '/example', { minTimes: 2 });
+      const id = map.add('GET', '/example', { toBeCalledAtLeast: 2 });
 
       // Assert
       expect(map.hasPendingRequests()).to.be.true;
 
-      // Act - Add the response twice, as we set minTimes to 2.
+      // Act - Add the response twice, as we set toBeCalledAtLeast to 2.
       const response = { statusCode: 200, statusMessage: 'OK', headers: { 'mock-header': 'yes' } };
       map.addResponse(id, { stuff: 1 }, { ...response, body: 'body-string-1' });
       map.addResponse(id, { stuff: 2 }, { ...response, body: 'body-string-2' });
@@ -183,11 +183,12 @@ describe('PlaybackRequestMap', () => {
       expect(map.serialize()).to.deep.equal({
         version: SERIALIZE_VERSION,
         matchers: [{
+          anyOnce: false,
           id: 'mock-request-matcher-id',
-          ignoredAttributes: [],
+          ignores: [],
           method: 'GET',
           matcher: '/example',
-          minTimes: 2,
+          atLeast: 2,
           responses: [
             {
               id: 'mock-intercepted-response-id-1',

--- a/lib/commands/entities/tests/PlaybackRequestMatcher.spec.js
+++ b/lib/commands/entities/tests/PlaybackRequestMatcher.spec.js
@@ -11,7 +11,13 @@ function createConstructorArgs(method, matcher, options = {}) {
   return [method, matcher, options];
 }
 
-function createSerializedRequestMatcher(id, minTimes, responseCount, ignoredAttributes = []) {
+function createSerializedRequestMatcher(
+  id,
+  atLeast,
+  responseCount,
+  anyOnce = false,
+  ignores = []
+) {
   const responses = [];
   for (let i = 0; i < responseCount; i++) {
     responses.push({
@@ -25,7 +31,7 @@ function createSerializedRequestMatcher(id, minTimes, responseCount, ignoredAttr
       headers: { 'mock-header': 'yes' },
     });
   }
-  return { id, minTimes, ignoredAttributes, responses };
+  return { id, atLeast, anyOnce, ignores, responses };
 }
 
 describe('PlaybackRequestMatcher', () => {
@@ -56,8 +62,9 @@ describe('PlaybackRequestMatcher', () => {
       // Assert
       expect(matcher.id).to.equal('mock-request-id');
       expect(matcher.matcher).to.equal('http://example.com/');
-      expect(matcher.minTimes).to.equal(1);
-      expect(matcher.ignoredAttributes).to.have.length(0);
+      expect(matcher.toBeCalledAtLeast).to.equal(1);
+      expect(matcher.anyOnce).to.equal(false);
+      expect(matcher.ignores).to.have.length(0);
     });
 
     it('throws if an incorrect number of arguments are provided.', () => {
@@ -69,8 +76,24 @@ describe('PlaybackRequestMatcher', () => {
       expect(() => new PlaybackRequestMatcher(1, '/')).to.throw()
         .property('message').to.match(/Invalid arguments/i);
 
-      expect(() => new PlaybackRequestMatcher('GET', null, { minTimes: 5 })).to.throw()
+      expect(() => new PlaybackRequestMatcher('GET', null, { toBeCalledAtLeast: 5 })).to.throw()
         .property('message').to.match(/Invalid arguments/i);
+    });
+
+    it('throws if "toBeCalledAtLeast" conflicts with "matching.anyOnce".', () => {
+      expect(() => new PlaybackRequestMatcher('GET', '/', { toBeCalledAtLeast: 5, matching: { anyOnce: true } }))
+        .to.throw().property('message').to.match(/"toBeCalledAtLeast" must be 1/i);
+    });
+
+    it('warns when using "matching.ignores" with "matching.anyOnce".', () => {
+      // Arrange
+      const consoleWarn = td.replace(console, 'warn');
+
+      // Act
+      new PlaybackRequestMatcher('GET', '/', { matching: { ignores: ['port'], anyOnce: true } });
+
+      // Assert
+      td.verify(consoleWarn(td.matchers.contains('"matching.ignores" is unnecessary')));
     });
   });
 
@@ -83,7 +106,7 @@ describe('PlaybackRequestMatcher', () => {
 
       // Assert
       expect(matcher.id).to.equal('mock-id');
-      expect(matcher.minTimes).to.equal(2);
+      expect(matcher.toBeCalledAtLeast).to.equal(2);
       expect(matcher.method).to.equal(serialized.method);
       expect(matcher.matcher).to.equal(serialized.matcher);
       expect(matcher.stale).to.be.true;
@@ -98,7 +121,7 @@ describe('PlaybackRequestMatcher', () => {
   describe('serialization', () => {
     it('works', () => {
       // Arrange
-      const args = createConstructorArgs('GET', 'http://example.com/', { minTimes: 5 });
+      const args = createConstructorArgs('GET', 'http://example.com/', { toBeCalledAtLeast: 5 });
       td.when(getRequestMatcherId(...args))
         .thenReturn('mock-request-id');
       td.when(getInterceptedResponseId(td.matchers.anything(), td.matchers.anything()))
@@ -113,10 +136,11 @@ describe('PlaybackRequestMatcher', () => {
       // Assert
       expect(serialized).to.deep.equal({
         id: 'mock-request-id',
-        ignoredAttributes: [],
+        ignores: [],
         method: 'GET',
         matcher: 'http://example.com/',
-        minTimes: 5,
+        atLeast: 5,
+        anyOnce: false,
         responses: [{
           id: 'mock-intercepted-response-id',
           statusCode: 200,
@@ -132,7 +156,7 @@ describe('PlaybackRequestMatcher', () => {
   describe('responses', () => {
     it('throws if notified of a response completing when none were started.', () => {
       // Arrange
-      const args = createConstructorArgs('GET', 'http://example.com/', { minTimes: 2 });
+      const args = createConstructorArgs('GET', 'http://example.com/', { toBeCalledAtLeast: 2 });
 
       // Act
       const matcher = new PlaybackRequestMatcher(...args);
@@ -141,9 +165,43 @@ describe('PlaybackRequestMatcher', () => {
         .property('message').to.match(/No requests inflight/i);
     });
 
+    it('returns a single response if "matching.anyOnce" set.', () => {
+      // Arrange
+      const serialized = createSerializedRequestMatcher('mock-id', 1, 1, true);
+
+      // Act
+      const matcher = new PlaybackRequestMatcher(serialized);
+      const allResponses = matcher.getAllResponses();
+
+      // Asesrt
+      expect(allResponses).to.have.length(1);
+
+      // Act
+      const response = matcher.getResponse('junk');
+
+      // Assert
+      expect(allResponses[0]).to.equal(response);
+    });
+
+    it('throws an error if more than one response is recorded when "matching.anyOnce" is set.', () => {
+      // Arrange
+      td.when(getInterceptedResponseId(td.matchers.anything(), td.matchers.anything()))
+        .thenReturn('mock-intercepted-response-id-1');
+      const args = createConstructorArgs('GET', 'http://example.com/', { toBeCalledAtLeast: 1, matching: { anyOnce: true } });
+
+      // Act
+      const matcher = new PlaybackRequestMatcher(...args);
+      matcher.addResponse(200, 'OK', 'body-string', { 'mock-header': 'yes' }, { stuff: true });
+
+      // Assert
+      expect(
+        () => matcher.addResponse(200, 'OK', 'body-string', { 'mock-header': 'yes' }, { stuff: true })
+      ).to.throw().property('message').to.match(/recorded more than one response/i);
+    });
+
     it('returns the expected "isPending" value for new requests.', () => {
       // Arrange
-      const args = createConstructorArgs('GET', 'http://example.com/', { minTimes: 2 });
+      const args = createConstructorArgs('GET', 'http://example.com/', { toBeCalledAtLeast: 2 });
       td.when(getRequestMatcherId(...args))
         .thenReturn('mock-request-id');
       td.when(getInterceptedResponseId(td.matchers.anything(), td.matchers.anything()))
@@ -153,7 +211,7 @@ describe('PlaybackRequestMatcher', () => {
       const matcher = new PlaybackRequestMatcher(...args);
       matcher.addResponse(200, 'OK', 'body-string', { 'mock-header': 'yes' }, { stuff: true });
 
-      // Assert - We set minTimes to 2, so the "add" above caused the response
+      // Assert - We set toBeCalledAtLeast to 2, so the "add" above caused the response
       // to have a "hit"
       expect(matcher.isPending()).to.be.true;
 
@@ -161,7 +219,7 @@ describe('PlaybackRequestMatcher', () => {
       matcher.getResponse('mock-intercepted-response-id');
 
       // Assert - We pulled out the response, so its hit count went up by one.
-      // Since the hit count now matches the minTimes count, the matcher is no
+      // Since the hit count now matches the toBeCalledAtLeast count, the matcher is no
       // longer pending.
       expect(matcher.isPending()).to.be.false;
     });

--- a/lib/commands/functions/getInterceptedResponseId.js
+++ b/lib/commands/functions/getInterceptedResponseId.js
@@ -1,5 +1,7 @@
 const md5 = require('blueimp-md5');
 
+const { stringifyBody } = require('./stringifyBody');
+
 // Note that if the order of the attributes here is ever changed, that will
 // cause any previously created ids to no longer match. Such a reorder should
 // be considered a breaking change, as mentioned below.
@@ -17,17 +19,36 @@ const defaultResponseAttributes = [
 ];
 
 /**
- * NOTE: Any changes to the values that are used to generate the id must be
- * accompanied by bumping the SERIALIZE_VERSION, as ids in existing playback
- * data will no longer match.
  * @param {CypressInterceptedRequest} request
- * @param {InterceptedResponseAttributes[]} ignoredAttributes
+ * @param {InterceptedResponseAttributes[] | ResponseMatchingIgnores } ignores
  * @returns {string}
  */
-function getInterceptedResponseId(request, ignoredAttributes) {
+function getInterceptedResponseId(request, ignores) {
+  if (typeof ignores !== 'object') {
+    throw new Error(`Ignores must be an object. Got: ${typeof ignores}`);
+  }
+  let ignoredAttributes,
+    ignoredBodyProperties,
+    ignoredSearchParams;
+
+  if (Array.isArray(ignores)) {
+    ignoredAttributes = ignores;
+    ignoredBodyProperties = [];
+    ignoredSearchParams = [];
+  } else {
+    ignoredAttributes = ignores.attributes || [];
+    ignoredBodyProperties = ignores.bodyProperties || [];
+    ignoredSearchParams = ignores.searchParams || [];
+  }
+
   const url = new URL(request.url);
   // Create an array of the request elements that should be included when
   // generating the id.
+  //
+  // NOTE: Removing any values from from the `requestElements` array or changing
+  // the format of the value in the array must be accompanied by bumping the
+  // SERIALIZE_VERSION, as ids in existing playback data will no longer match.
+  // Add new features or values does not require a version bump.
   const requestElements = defaultResponseAttributes.reduce(
     (acc, attribute) => {
       if (ignoredAttributes.includes(attribute)) {
@@ -38,9 +59,17 @@ function getInterceptedResponseId(request, ignoredAttributes) {
         case 'hostname':
         case 'port':
         case 'pathname':
-        case 'search': {
           if (url[attribute]) {
             acc.push(url[attribute]);
+          }
+          break;
+        case 'search': {
+          for (const param of ignoredSearchParams) {
+            url.searchParams.delete(param);
+          }
+          const search = url.searchParams.toString();
+          if (search){
+            acc.push(`?${url.searchParams.toString()}`);
           }
           break;
         }
@@ -53,12 +82,7 @@ function getInterceptedResponseId(request, ignoredAttributes) {
           if (bodyAsString == null) {
             throw new Error('Request body must be provided.');
           }
-
-          if (typeof bodyAsString !== 'string') {
-            // Form submissions are probably going to cause real problems here.
-            bodyAsString = JSON.stringify(request.body);
-          }
-          acc.push(bodyAsString);
+          acc.push(stringifyBody(bodyAsString, ignoredBodyProperties));
           break;
         }
       }

--- a/lib/commands/functions/stringifyBody.js
+++ b/lib/commands/functions/stringifyBody.js
@@ -1,0 +1,54 @@
+function getPropertyPathSegment(key) {
+  // Use bracket notation if there is any whitespace in the key.
+  const bracketNotation = !/^\w+$/.test(key);
+  return {
+    bracketNotation,
+    segment: bracketNotation ? `[${JSON.stringify(key)}]` : key
+  };
+}
+
+/**
+ * Returns the stringified version of the body with any ignored properties
+ * removed.
+ * @param {string|{}} body
+ * @param {string[]} removedProperties
+ * @returns {string}
+ */
+function stringifyBody(body, removedProperties) {
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  const toRemove = new Set(removedProperties);
+  const objectPaths = new Map();
+
+  return JSON.stringify(
+    body,
+    function (key, value) {
+      if (!key) {
+        // No key = the root object.
+        return value;
+      }
+
+      const { bracketNotation, segment } = getPropertyPathSegment(key);
+      const basePath = objectPaths.get(this) ?? '';
+      const path = basePath
+        + (basePath && !bracketNotation ? '.' : '')
+        + segment;
+
+      if (toRemove.has(path)) {
+        return undefined;
+      }
+
+      if (typeof value === 'object') {
+        objectPaths.set(value, path);
+      }
+
+      return value;
+    }
+  );
+}
+
+module.exports = {
+  stringifyBody
+};

--- a/lib/commands/functions/tests/getInterceptedResponseId.spec.js
+++ b/lib/commands/functions/tests/getInterceptedResponseId.spec.js
@@ -4,9 +4,9 @@ const md5 = td.func();
 // Subject-under-test
 let getInterceptedResponseId;
 
-function createMockRequest(body) {
+function createMockRequest(body, search = 'foo=bar') {
   return {
-    url: 'https://example.com:4444?foo=bar',
+    url: `https://example.com:4444?${search}`,
     method: 'GET',
     body,
   };
@@ -39,11 +39,29 @@ describe('getInterceptedResponseId', () => {
   });
 
   describe('with ignores', () => {
-    it('calls the md5 function as expected', () => {
+    it('calls the md5 function without search attribute.', () => {
       td.when(md5(['https:', 'example.com', '4444', '/', 'GET', 'body-string'].join('::')))
         .thenReturn('md5-hash');
 
       expect(getInterceptedResponseId(createMockRequest('body-string'), ['search'])).to.equal('md5-hash');
+    });
+
+    it('calls the md5 function without ignored search params.', () => {
+      td.when(md5(['https:', 'example.com', '4444', '/', '?baz=quux', 'GET', 'body-string'].join('::')))
+        .thenReturn('md5-hash');
+
+      expect(getInterceptedResponseId(
+        createMockRequest('body-string', 'foo=bar&baz=quux'), { searchParams: ['foo'] })
+      ).to.equal('md5-hash');
+    });
+
+    it('calls the md5 function without ignored body property.', () => {
+      td.when(md5(['https:', 'example.com', '4444', '/', '?foo=bar', 'GET', '{}'].join('::')))
+        .thenReturn('md5-hash');
+
+      expect(getInterceptedResponseId(
+        createMockRequest({ baz: 'quux' }), { bodyProperties: ['baz'] })
+      ).to.equal('md5-hash');
     });
   });
 
@@ -51,6 +69,10 @@ describe('getInterceptedResponseId', () => {
     it('when the request has no body.', () => {
       expect(() => getInterceptedResponseId(createMockRequest(), [])).to.throw()
         .property('message').to.match(/Request body must be provided/);
+    });
+    it('when the ignores argument is not an object.', () => {
+      expect(() => getInterceptedResponseId(createMockRequest('body-string'), 'not-an-object')).to.throw()
+        .property('message').to.match(/Ignores must be an object/);
     });
   });
 });

--- a/lib/commands/functions/tests/getRequestMatcherId.spec.js
+++ b/lib/commands/functions/tests/getRequestMatcherId.spec.js
@@ -1,27 +1,24 @@
-// Mocked dependencies.
-const getMatcherAsString = td.func();
-const md5 = td.func();
-
 // Subject-under-test
-let getRequestMatcherId;
+const { getRequestMatcherId } = require('../getRequestMatcherId');
 
 describe('getRequestMatcherId', () => {
-  before(() => {
-    td.replace('blueimp-md5', md5);
-    td.replace('../getMatcherAsString', { getMatcherAsString });
-    ({ getRequestMatcherId } = require('../getRequestMatcherId.js'));
+  it('should return unique ids', () => {
+    const options = {
+      matching: { ignores: ['hostname', 'port'] },
+      rewriteOrigin: 'https://example.com'
+    };
+    const id1 = getRequestMatcherId('GET', '/api/v1/foo/', { ...options });
+    const id2 = getRequestMatcherId('GET', '/api/v1/foo/*', { ...options });
+    expect(id1).to.not.equal(id2);
   });
 
-  afterEach(() => {
-    td.reset();
-  });
-
-  it('calls "md5" with the expected values.', () => {
-    // Arrange
-    td.when(getMatcherAsString('/')).thenReturn('matcher-as-string');
-    td.when(md5('GET::matcher-as-string::{"options":true}')).thenReturn('md5-hash');
-
-    // Act
-    expect(getRequestMatcherId('GET', '/', { options: true })).to.equal('md5-hash');
+  it('should return the same ids with the same inputs', () => {
+    const options = {
+      matching: { ignores: ['hostname', 'port'] },
+      rewriteOrigin: 'https://example.com'
+    };
+    const id1 = getRequestMatcherId('GET', '/api/v1/foo/', { ...options });
+    const id2 = getRequestMatcherId('GET', '/api/v1/foo/', { ...options });
+    expect(id1).to.equal(id2);
   });
 });

--- a/lib/commands/functions/tests/stringifyBody.spec.js
+++ b/lib/commands/functions/tests/stringifyBody.spec.js
@@ -1,0 +1,50 @@
+const { stringifyBody } = require('../stringifyBody');
+
+describe('stringifyBody', () => {
+  it('should remove properties as expected.', () => {
+    // Arrange
+    const body = {
+      foo: 'bar',
+      nested1: {
+        nested2: {
+          baz: 'qux',
+        }
+      },
+      array: [
+        {
+          quux: 'garply',
+          'A Nested Array': [{
+            waldo: 'fred'
+          }]
+        },
+        {
+          xyzzy: 'thud'
+        }
+      ]
+    };
+
+    const removedProperties = [
+      'foo',
+      'nested1.nested2.baz',
+      'array.0.quux',
+      'array.0["A Nested Array"].0.waldo',
+      'array.1.xyzzy'
+    ];
+
+    // Act
+    const result = JSON.parse(stringifyBody(body, removedProperties));
+
+    // Assert
+    expect(result).to.deep.equal({
+      nested1: { nested2: { } },
+      array: [
+        { 'A Nested Array': [{}] },
+        {}
+      ]
+    });
+  });
+
+  it('should handle a "string" body.', () => {
+    expect(stringifyBody('body-string', [])).to.equal('body-string');
+  });
+});

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -78,9 +78,15 @@ afterEach(function playbackAfterEach() {
       });
     })
     .then(() => {
+      const allRequests = map.getAll().map(request => {
+        return {
+          matcher: `${request.method} ${request.matcher}`,
+          responses: request.getAllResponses().map(response => response.serialize())
+        };
+      });
+
       if (map.hasPendingRequests()) {
         const pendingRequests = map.getPendingRequests().map(request => `${request.method} ${request.matcher}`);
-        const allRequests = map.getAll().map(request => `${request.method} ${request.matcher}`);
         // Update the log for the error state.
         log.set('message', `${pendingRequests.length} pending requests.`)
           .set('consoleProps', () => ({
@@ -92,8 +98,14 @@ afterEach(function playbackAfterEach() {
         this.currentTest.state = 'failed';
         return;
       }
+
       log.set('message', 'No pending requests.')
+        .set('consoleProps', () => ({
+          'Pending Requests': [],
+          'All Requests': allRequests,
+        }))
         .end();
+
       // Sealing the map will cause errors to be thrown if we try to add new
       // responses to the map.
       map.seal();
@@ -120,7 +132,7 @@ const playback = {
         const response = map.getResponse(id, req, options);
         if (response) {
           try {
-            req.reply(response.statusCode,response.body, response.headers);
+            req.reply(response.statusCode, response.body, response.headers);
           } catch (e) {
             console.error(response);
             throw e;
@@ -128,7 +140,16 @@ const playback = {
           return;
         } else if (!isPlaybackMode('hybrid')) {
           // TODO: Improve error message.
-          const message = `CYPRESS PLAYBACK: No response found for request '${req.method}:${req.url}'`;
+          Cypress.log({
+            name: 'assert',
+            displayName: 'Playback',
+            message: 'No response found for request.',
+            consoleProps: () => ({
+              'Request Url': `${req.method} ${req.url}`,
+              'Expected Response Id': id,
+            })
+          }).error();
+          const message = `CYPRESS PLAYBACK: No response found for request '${req.method} ${req.url}'`;
           req.reply({ statusCode: 404, body: { message } });
           throw new Error(message);
         }
@@ -140,14 +161,14 @@ const playback = {
         delete req.headers['if-none-match'];
 
         let originalRequestData = null;
-        if (typeof options?.recording?.rewriteOrigin === 'string') {
+        if (typeof options?.rewriteOrigin === 'string') {
           originalRequestData = {
             url: req.url,
             headers: { ...req.headers }
           };
 
           // Update the URL.
-          const rewriteUrl = new URL(options.recording.rewriteOrigin, req.url);
+          const rewriteUrl = new URL(options.rewriteOrigin, req.url);
           const url = new URL(req.url);
           rewriteUrl.search = new URLSearchParams(req.query);
           rewriteUrl.pathname = url.pathname;
@@ -176,7 +197,7 @@ const playback = {
 
           if (
             (res.statusCode >= 200 && res.statusCode < 300)
-            || options?.recording?.allowAllStatusCodes
+            || options?.allowAllStatusCodes
           ) {
             map.addResponse(id, req, res);
           } else {

--- a/lib/commands/types.js
+++ b/lib/commands/types.js
@@ -21,11 +21,17 @@
  * @property {string | {} | ArrayBuffer} body
  *
  * @typedef {Object} RequestMatcherOptions
- * @property {number} minTimes
- * @property {Object} recording
- * @property {InterceptedResponseAttributes} recording.matchingIgnores
- * @property {string} recording.rewriteOrigin
- * @property {string} recording.allowAllStatusCodes
+ * @property {boolean} allowAllStatusCodes
+ * @property {number} toBeCalledAtLeast
+ * @property {Object} matching
+ * @property {boolean} matching.anyOnce
+ * @property {InterceptedResponseAttributes[] | ResponseMatchingIgnores} matching.ignores
+ * @property {string} rewriteOrigin
+ *
+ * @typedef {Object} ResponseMatchingIgnores
+ * @property {InterceptedResponseAttributes} attributes
+ * @property {string[]} bodyProperties
+ * @property {string[]} searchParams
  *
  * @typedef {Object} SerializedPlaybackResponse
  *

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@oreillymedia/cypress-playback",
       "version": "1.0.3",
-      "license": "MIT",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
         "lodash.kebabcase": "^4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@oreillymedia/cypress-playback-root",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "BSD-3-Clause"
     }
   }
 }

--- a/sandbox/cypress/integration/app.spec.js
+++ b/sandbox/cypress/integration/app.spec.js
@@ -5,7 +5,7 @@ describe('local to-do app', () => {
       cy.isRecordingRequests().then(isRecording => {
         // The scripts defined in the `package.json` cause the server to be run
         // at 8081 when recording and 8082 when playing back. This is to allow
-        // us to test the `matchingIgnores` feature.
+        // us to test the `matching.ignores` feature.
         if (isRecording) {
           baseUrl = `http://localhost:${8081}/`;
         } else if (isPlayingBack) {
@@ -20,7 +20,7 @@ describe('local to-do app', () => {
   it('does something', () => {
     cy.playback('GET', new RegExp('./assets/static-image.jpeg'),
       {
-        recording: { matchingIgnores: ['port'] }
+        matching: { ignores: ['port'] }
       }
     ).as('static');
 
@@ -28,7 +28,7 @@ describe('local to-do app', () => {
 
     cy.playback('GET', new RegExp('/todos/'),
       {
-        minTimes: 2
+        toBeCalledAtLeast: 2
       }
     ).as('todos');
 

--- a/sandbox/package-lock.json
+++ b/sandbox/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@oreillymedia/cypress-playback-sandbox",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "BSD-3-Clause",
       "devDependencies": {
         "@testing-library/cypress": "^8.0.2",
         "cypress": "^9.0.0",
@@ -251,9 +251,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz",
-      "integrity": "sha512-j11XSuRuAlft6vLDEX4RvhqC0KxNxx6QIyMXNb0vHHSNPXTPeiy3algESWmOOIzEtiEL0qiowPU3ewW9hHVa7Q==",
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
       "dev": true
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -573,18 +573,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -752,9 +740,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.3.1.tgz",
-      "integrity": "sha512-BODdPesxX6bkVUnH8BVsV8I/jn57zQtO1FEOUTiuG2us3kslW7g0tcuwiny7CKCmJUZz8S/D587ppC+s58a+5Q==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.4.1.tgz",
+      "integrity": "sha512-+JgMG9uT+QFx97JU9kOHE3jO3+0UdkQ9H1oCBiC7A74qme7Jkdy2sYDBCPjjGczutnWnGUTMRlwiNMP/Uq6LrQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -795,10 +783,10 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "bin": {
@@ -806,6 +794,21 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cypress/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/dashdash": {
@@ -1424,9 +1427,9 @@
       "dev": true
     },
     "node_modules/joi": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.5.0.tgz",
-      "integrity": "sha512-R7hR50COp7StzLnDi4ywOXHrBrgNXuUUfJWIR5lPY5Bm/pOD3jZaTwpluUXVLRWcoWZxkrHBBJ5hLxgnlehbdw==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
@@ -1598,6 +1601,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/lz-string": {
@@ -1938,16 +1953,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -2035,6 +2040,21 @@
       "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
       "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
       "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2226,18 +2246,15 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/throttleit": {
@@ -2343,26 +2360,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
     "node_modules/url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "dev": true
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
     },
     "node_modules/uuid": {
@@ -2455,6 +2456,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "node_modules/yauzl": {
@@ -2672,9 +2679,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz",
-      "integrity": "sha512-j11XSuRuAlft6vLDEX4RvhqC0KxNxx6QIyMXNb0vHHSNPXTPeiy3algESWmOOIzEtiEL0qiowPU3ewW9hHVa7Q==",
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
       "dev": true
     },
     "@types/sinonjs__fake-timers": {
@@ -2899,17 +2906,6 @@
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "check-more-types": {
@@ -3038,9 +3034,9 @@
       }
     },
     "cypress": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.3.1.tgz",
-      "integrity": "sha512-BODdPesxX6bkVUnH8BVsV8I/jn57zQtO1FEOUTiuG2us3kslW7g0tcuwiny7CKCmJUZz8S/D587ppC+s58a+5Q==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.4.1.tgz",
+      "integrity": "sha512-+JgMG9uT+QFx97JU9kOHE3jO3+0UdkQ9H1oCBiC7A74qme7Jkdy2sYDBCPjjGczutnWnGUTMRlwiNMP/Uq6LrQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -3080,11 +3076,22 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "dashdash": {
@@ -3542,9 +3549,9 @@
       "dev": true
     },
     "joi": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.5.0.tgz",
-      "integrity": "sha512-R7hR50COp7StzLnDi4ywOXHrBrgNXuUUfJWIR5lPY5Bm/pOD3jZaTwpluUXVLRWcoWZxkrHBBJ5hLxgnlehbdw==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
       "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0",
@@ -3678,6 +3685,15 @@
             "strip-ansi": "^6.0.0"
           }
         }
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
       }
     },
     "lz-string": {
@@ -3941,12 +3957,6 @@
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
-    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -4025,6 +4035,15 @@
       "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
       "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
       "dev": true
+    },
+    "semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -4166,9 +4185,9 @@
       "dev": true
     },
     "supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
@@ -4253,24 +4272,6 @@
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "dev": true
     },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
-        }
-      }
-    },
     "url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -4340,6 +4341,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yauzl": {

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -10,7 +10,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "BSD-3-Clause",
   "devDependencies": {
     "@testing-library/cypress": "^8.0.2",
     "cypress": "^9.0.0",


### PR DESCRIPTION
### Summary

- Add `matching.ignores.bodyProperties` and `matching.ignores.searchParams` functionality to `playbackOptions`.
  - These cause body properties and search parameters to be ignored when trying to find a matching response.
- Add `matching.anyOnce` functionality to `playbackOptions`.
  - This tells a request matcher to only expect a single response and return that response even if the response id doesn't match during playback.
- Dump all request matchers and responses to console if `afterEach` log is clicked in the side bar after a successful test run.
- Dump the unmatched response id to the console if `afterEach` log is clicked in the side bar after a failed test run.
- **BREAKING CHANGE:** Restructure the `playbackOptions` properties to make their function easier to understand and convey their relationship to each other.

### Related Issue(s)

n/a

### Checklist

* [X] Follows [Contributing guidelines][1].
* [X] Pull Request title uses [Conventional Commit syntax][2].
* [X] All tests pass.
* [X] Linted code.
* [X] Authored new tests, if necessary.
* [x] Updated documentation, if necessary.

[1]:https://github.com/oreillymedia/cypress-playback/blob/main/CONTRIBUTING.md
[2]:https://www.conventionalcommits.org/en/v1.0.0/#summary