### PR TITLE
fix: Remove 'content-encoding' header in playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,20 +117,21 @@ command's ["RouteMatcher"][3] documentation for more details.
 ##### **playbackOptions (PlaybackOptions)**
 
 `playbackOptions` is an object used to modify the behavior of the `playback`
-command. Below is an example object using all of the available properties.
+command. The example object below is showing the default values for all
+available properties.
 
 ```JavaScript
 {
-  allowAllStatusCodes: true,
+  allowAllStatusCodes: false,
   toBeCalledAtLeast: 1,
   matching: {
     ignores: {
-      attributes: ['port'],
-      bodyProperties: ['timestamp'],
-      searchParams: ['date']
+      attributes: [],
+      bodyProperties: [],
+      searchParams: []
     }
   },
-  rewriteOrigin: 'https://not-example.com'
+  rewriteOrigin: undefined
 }
 ```
 

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -132,6 +132,11 @@ const playback = {
         const response = map.getResponse(id, req, options);
         if (response) {
           try {
+            // We need to delete the 'content-encoding' header, as the recorded
+            // response will not have the body in that format.
+            // Notes on 'content-encoding':
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
+            delete response.headers['content-encoding'];
             req.reply(response.statusCode, response.body, response.headers);
           } catch (e) {
             console.error(response);
@@ -185,6 +190,7 @@ const playback = {
           map.notifyRequestCompleted(id);
           // Make sure the browser does not try to use a cached response.
           res.headers['cache-control'] = 'no-cache';
+
           if (originalRequestData) {
             if (res.headers['access-control-allow-origin']) {
               res.headers['access-control-allow-origin'] = '*';


### PR DESCRIPTION
### Summary

- Remove the `content-encoding` header when playing back a response, as that recorded response will not be in the compressed format.
- Update the README to show default values for `playbackOptions` properties.

### Related Issue(s)

n/a

### Checklist

* [X] Follows [Contributing guidelines][1].
* [X] Pull Request title uses [Conventional Commit syntax][2].
* [X] All tests pass.
* [X] Linted code.
* [X] Authored new tests, if necessary.
* [X] Updated documentation, if necessary.

[1]:https://github.com/oreillymedia/cypress-playback/blob/main/CONTRIBUTING.md
[2]:https://www.conventionalcommits.org/en/v1.0.0/#summary