### PR TITLE
fix: remove or flatten header arrays in response

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -133,10 +133,23 @@ const playback = {
         if (response) {
           try {
             // We need to delete the 'content-encoding' header, as the recorded
-            // response will not have the body in that format.
+            // response will not have the body in that format due to compression.
             // Notes on 'content-encoding':
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
             delete response.headers['content-encoding'];
+            // Any headers that contain an array need to be either flattened
+            // if they only have one entry or deleted as Cypress does not
+            // handle array headers in response:
+            // 'An invalid StaticResponse was supplied to req.reply(). headers must be a map of strings to strings.'
+            for (const [key, value] of Object.entries(response.headers)){
+              if(Array.isArray(value) && value.length === 1) {
+                console.log(`Flattening response header "${key}"`);
+                response.headers[key] = value[0];
+              } else if(Array.isArray(value) && value.length >= 1) {
+                delete response.headers[key];
+                console.warn(`The response header "${key}" is an Array with multiple entries and was deleted.`);
+              }
+            }
             req.reply(response.statusCode, response.body, response.headers);
           } catch (e) {
             console.error(response);


### PR DESCRIPTION
### Summary

In cases where headers contained an array, the response playback would fail with the following message:

```js
An invalid StaticResponse was supplied to req.reply(). headers must be a map of strings to strings.
```

An example of this in an header I encountered was

```js
  "set-cookie": [
      "_cookiekey; Path=/"
    ],
```

This change iterates through the headers flattening any arrays that have a length of 1 and removing ones that are multiple entries.

### Checklist

* [x] Follows [Contributing guidelines][1].
* [x] Pull Request title uses [Conventional Commit syntax][2].
* [x] All tests pass.
* [x] Linted code.
* [x] Authored new tests, if necessary.
* [x] Updated documentation, if necessary.

[1]:https://github.com/oreillymedia/cypress-playback/blob/main/CONTRIBUTING.md
[2]:https://www.conventionalcommits.org/en/v1.0.0/#summary