### PR TITLE
fix: Set 'access-control-allow-origin' to window origin

### DIFF
--- a/lib/commands/entities/PlaybackResponse.js
+++ b/lib/commands/entities/PlaybackResponse.js
@@ -80,10 +80,17 @@ class PlaybackResponse {
   #hits = 0;
 
   get id() { return this.#id; }
+
   get statusCode() { return this.#statusCode; }
+
   get statusMessage() { return this.#statusMessage; }
+
   get body() { return this.#body; }
+
   get headers() { return this.#headers; }
+  /* c8 ignore next */
+  set headers(value) { this.#headers = value; }
+
   get hits() { return this.#hits; }
 
   /**

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -132,24 +132,45 @@ const playback = {
         const response = map.getResponse(id, req, options);
         if (response) {
           try {
-            // We need to delete the 'content-encoding' header, as the recorded
-            // response will not have the body in that format due to compression.
-            // Notes on 'content-encoding':
-            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
-            delete response.headers['content-encoding'];
-            // Any headers that contain an array need to be either flattened
-            // if they only have one entry or deleted as Cypress does not
-            // handle array headers in response:
-            // 'An invalid StaticResponse was supplied to req.reply(). headers must be a map of strings to strings.'
-            for (const [key, value] of Object.entries(response.headers)){
-              if(Array.isArray(value) && value.length === 1) {
-                console.log(`Flattening response header "${key}"`);
-                response.headers[key] = value[0];
-              } else if(Array.isArray(value) && value.length >= 1) {
-                delete response.headers[key];
-                console.warn(`The response header "${key}" is an Array with multiple entries and was deleted.`);
-              }
-            }
+            // Update the headers so they work correctly when being played back.
+            response.headers = Object.fromEntries(Object.entries(response.headers).reduce(
+              (acc, [key, value]) => {
+                switch (key.toLowerCase()) {
+                  case 'content-encoding':
+                    // We need to remove the 'content-encoding' header, as the
+                    // recorded response will not have the body in that format
+                    // due to compression. Notes on 'content-encoding':
+                    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
+                    break;
+                  case 'access-control-allow-origin': {
+                    // We may not be playing back on the same origin that we
+                    // recorded, so update to the current origin.
+                    acc.push([key, window.origin]);
+                    break;
+                  }
+                  default: {
+                    // Any headers that contain an array need to be either flattened
+                    // if they only have one entry or deleted as Cypress does not
+                    // handle array headers in response:
+                    // 'An invalid StaticResponse was supplied to req.reply(). headers must be a map of strings to strings.'
+                    if (Array.isArray(value)) {
+                      if (value.length === 1) {
+                        console.log('CYPRESS PLAYBACK:', `Flattening response header "${key}"`);
+                        acc.push([key, value[0]]);
+                      } else {
+                        console.warn('CYPRESS PLAYBACK:', `The response header "${key}" is an Array with multiple entries and was deleted.`);
+                      }
+                    } else {
+                      acc.push([key, value]);
+                    }
+                    break;
+                  }
+                }
+                return acc;
+              },
+              []
+            ));
+
             req.reply(response.statusCode, response.body, response.headers);
           } catch (e) {
             console.error(response);
@@ -204,9 +225,7 @@ const playback = {
           // Make sure the browser does not try to use a cached response.
           res.headers['cache-control'] = 'no-cache';
           if (res.headers['access-control-allow-origin']) {
-            // Allow all origins, as this respones may be played back on a
-            // different origin.
-            res.headers['access-control-allow-origin'] = '*';
+            res.headers['access-control-allow-origin'] = window.origin;
           }
 
           if (originalRequestData) {


### PR DESCRIPTION
### Summary

- Set the `access-control-allow-origin` to the current window origin.
  - In cases where the `access-control-allow-credentials` was set to true, the wildcard (`*`) value for `access-control-allowed-origin` would cause calls to `fetch` with `credentials: 'include'` set to fail.
  - Since we are now setting multiple headers, cleaned up the code a bit so that we iterate over the header properties once, omitting or updating header values as needed.

### Related Issue(s)

n/a

### Checklist

* [X] Follows [Contributing guidelines][1].
* [X] Pull Request title uses [Conventional Commit syntax][2].
* [X] All tests pass.
* [X] Linted code.
* [X] Authored new tests, if necessary.
* [X] Updated documentation, if necessary.

[1]:https://github.com/oreillymedia/cypress-playback/blob/main/CONTRIBUTING.md
[2]:https://www.conventionalcommits.org/en/v1.0.0/#summary