### PR TITLE
fix: get invocation details from parent

### DIFF
--- a/lib/commands/functions/getTestMetadata.js
+++ b/lib/commands/functions/getTestMetadata.js
@@ -9,7 +9,8 @@ function getTestMetadata(context) {
     throw new Error('No "test" in context');
   }
 
-  const file = test.invocationDetails?.absoluteFile;
+  const invocationDetails = test.invocationDetails || test.parent?.invocationDetails;
+  const file = invocationDetails?.absoluteFile;
 
   let titles = [test.title];
   let parent = test.parent;


### PR DESCRIPTION
### Summary

Gets invocation details from the parent if doesn't exist on the test. `test.invocationDetails` is missing during a few instances but `test.parent.invocationDetails` is available and point to the desired file path. I'm unsure what the root cause is - if this is a known issue / case please let me know! I'm running cypress 9.6.1.

### Related Issue(s)

N/A

### Checklist

* [x] Follows [Contributing guidelines][1].
* [x] Pull Request title uses [Conventional Commit syntax][2].
* [x] All tests pass.
* [x] Linted code.
* [x] Authored new tests, if necessary.
* [x] Updated documentation, if necessary.

[1]:https://github.com/oreillymedia/cypress-playback/blob/main/CONTRIBUTING.md
[2]:https://www.conventionalcommits.org/en/v1.0.0/#summary