### PR TITLE
fix: change package cdn from unpkg to jsdelivr

### DIFF
--- a/sandbox/app/index.html
+++ b/sandbox/app/index.html
@@ -7,13 +7,13 @@
         content="IE=edge">
   <meta name="viewport"
         content="width=device-width, initial-scale=1.0">
-  <script src="https://unpkg.com/react@latest/umd/react.production.min.js"
+  <script src="https://cdn.jsdelivr.net/npm/react@latest/umd/react.production.min.js"
           crossorigin></script>
-  <script src="https://unpkg.com/react-dom@latest/umd/react-dom.production.min.js"
+  <script src="https://cdn.jsdelivr.net/npm/react-dom@latest/umd/react-dom.production.min.js"
           crossorigin></script>
-  <script src="https://unpkg.com/@mui/material@latest/umd/material-ui.development.js"
+  <script src="https://cdn.jsdelivr.net/npm/@mui/material@latest/umd/material-ui.production.min.js"
           crossorigin="anonymous"></script>
-  <script src="https://unpkg.com/esbuild-wasm@0.14.11/lib/browser.min.js"
+  <script src="https://cdn.jsdelivr.net/npm/esbuild-wasm@0.14.11/lib/browser.min.js"
           crossorigin></script>
   <link rel="stylesheet"
         href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
@@ -21,7 +21,7 @@
         href="https://fonts.googleapis.com/icon?family=Material+Icons" />
   <script type="module">
     await esbuild.initialize({
-      wasmURL: "https://unpkg.com/esbuild-wasm@0.14.11/esbuild.wasm",
+      wasmURL: "https://cdn.jsdelivr.net/npm/esbuild-wasm@0.14.11/esbuild.wasm",
     });
 
     window.compileJsxModule = async function compileJsxModule(filePath, entryPoint) {


### PR DESCRIPTION
### Summary

Running this sandbox does not currently work as the `@mui/material` package is not found. It does not look like [unpkg](https://github.com/mjackson/unpkg/issues) is actively supported any longer, so switching to [jsdelivr](https://www.jsdelivr.com/unpkg) instead

### Checklist

* [x] Follows [Contributing guidelines][1].
* [x] Pull Request title uses [Conventional Commit syntax][2].
* [x] All tests pass.
* [x] Linted code.
* [x] Authored new tests, if necessary.
* [x] Updated documentation, if necessary.

[1]:https://github.com/oreillymedia/cypress-playback/blob/main/CONTRIBUTING.md
[2]:https://www.conventionalcommits.org/en/v1.0.0/#summary